### PR TITLE
page_store: fix miss page in fileinfo::active_pages

### DIFF
--- a/src/page_store/page_file/file_builder.rs
+++ b/src/page_store/page_file/file_builder.rs
@@ -136,7 +136,7 @@ impl<'a, E: Env> FileBuilder<'a, E> {
 
         let active_pages = {
             let mut active_pages = roaring::RoaringBitmap::new();
-            for page_addr in self.meta.page_table.0.values() {
+            for page_addr in meta.data_offsets().keys() {
                 let (_, index) = split_page_addr(*page_addr);
                 active_pages.insert(index);
             }

--- a/src/page_store/page_file/info_builder.rs
+++ b/src/page_store/page_file/info_builder.rs
@@ -69,13 +69,9 @@ impl<E: Env> FileInfoBuilder<E> {
         let meta = meta_reader.file_metadata();
 
         let active_pages = {
-            let page_table = meta_reader
-                .read_page_table()
-                .await
-                .expect("read page table error");
             let mut active_pages = roaring::RoaringBitmap::new();
-            for (_page_id, page_addr) in page_table {
-                let (_, index) = split_page_addr(page_addr);
+            for page_addr in meta.data_offsets().keys() {
+                let (_, index) = split_page_addr(*page_addr);
                 active_pages.insert(index);
             }
             active_pages

--- a/src/page_store/page_file/mod.rs
+++ b/src/page_store/page_file/mod.rs
@@ -374,6 +374,42 @@ pub(crate) mod facade {
             }
         }
 
+        #[photonio::test]
+        fn test_get_child_page() {
+            let env = crate::env::Photon;
+            let files = {
+                let base = std::env::temp_dir();
+                PageFiles::new(env, &base, "test_get_child_page").await
+            };
+            let info_builder = files.new_info_builder();
+
+            let file_id = 1;
+            let page_addr1 = page_addr(file_id, 0);
+            let page_addr2 = page_addr(file_id, 1);
+
+            {
+                let mut b = files.new_file_builder(file_id).await.unwrap();
+                b.add_page(1, page_addr1, &[1].repeat(10)).await.unwrap();
+                b.add_page(1, page_addr2, &[2].repeat(10)).await.unwrap();
+                let file_info = b.finish().await.unwrap();
+                assert!(file_info.get_page_handle(page_addr1).is_some())
+            }
+
+            {
+                let known_files = &[file_id]
+                    .iter()
+                    .cloned()
+                    .map(Into::into)
+                    .collect::<Vec<_>>();
+                let recovery_mock_version = info_builder
+                    .recovery_base_file_infos(known_files)
+                    .await
+                    .unwrap();
+                let file1 = recovery_mock_version.get(&1).unwrap();
+                assert!(file1.get_page_handle(page_addr1).is_some())
+            }
+        }
+
         fn page_addr(file_id: u32, index: u32) -> u64 {
             ((file_id as u64) << 32) | (index as u64)
         }

--- a/src/page_store/page_file/mod.rs
+++ b/src/page_store/page_file/mod.rs
@@ -396,13 +396,8 @@ pub(crate) mod facade {
             }
 
             {
-                let known_files = &[file_id]
-                    .iter()
-                    .cloned()
-                    .map(Into::into)
-                    .collect::<Vec<_>>();
                 let recovery_mock_version = info_builder
-                    .recovery_base_file_infos(known_files)
+                    .recovery_base_file_infos(&[file_id.into()])
                     .await
                     .unwrap();
                 let file1 = recovery_mock_version.get(&1).unwrap();

--- a/src/page_store/page_file/types.rs
+++ b/src/page_store/page_file/types.rs
@@ -143,15 +143,15 @@ impl FileMeta {
     pub(crate) fn new(
         file_id: u32,
         file_size: usize,
-        indexes: Vec<u64>,
-        offsets: BTreeMap<u64, u64>,
+        meta_indexes: Vec<u64>,
+        data_offsets: BTreeMap<u64, u64>,
         block_size: usize,
     ) -> Self {
         Self {
             file_id,
             file_size,
-            meta_indexes: indexes,
-            data_offsets: offsets,
+            meta_indexes,
+            data_offsets,
             block_size,
         }
     }
@@ -194,6 +194,11 @@ impl FileMeta {
     #[inline]
     pub(crate) fn block_size(&self) -> usize {
         self.block_size
+    }
+
+    #[inline]
+    pub(crate) fn data_offsets(&self) -> &BTreeMap<u64, u64> {
+        &self.data_offsets
     }
 
     pub(crate) fn get_page_table_meta_page(


### PR DESCRIPTION
the bug will let the non-root page in the page-chain be invisible

just as test case https://github.com/photondb/photondb/pull/183/files#diff-80135876669825a2d131566577bc0e889091c9346362e41cf881abe1829a7247R377