### PR TITLE
page_store: disable direct_io when force tokio in linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ debug = true
 
 [profile.release]
 debug = true
+
+[features]
+force-tokio = ["photonio/tokio"]

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -201,7 +201,7 @@ pub struct Metadata {
     pub is_dir: bool,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(not(feature = "force-tokio"), target_os = "linux"))]
 pub(in crate::env) fn direct_io_ify(fd: i32) -> Result<()> {
     macro_rules! syscall {
             ($fn: ident ( $($arg: expr),* $(,)* ) ) => {{
@@ -219,7 +219,7 @@ pub(in crate::env) fn direct_io_ify(fd: i32) -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(any(feature = "force-tokio", not(target_os = "linux")))]
 pub(in crate::env) fn direct_io_ify(_: i32) -> Result<()> {
     Err(std::io::Error::new(
         std::io::ErrorKind::Unsupported,


### PR DESCRIPTION
closes #175

After some investigation the root cause for 175 is 'tokio-runtime-worker', tokio's [AsyncWriteExt::write_all](https://docs.rs/tokio/latest/tokio/io/trait.AsyncWriteExt.html#method.write_all) will use self-alloc buffer instead of using our aligned buffer parameter, so it's better to disable direct_io when using tokio.

(ps: I also run some randgen tests for different size buffers and pos in photonio-uring impl, it's no EINVAL until now)

Combine with https://github.com/photondb/photonio/blob/main/photonio/src/lib.rs#L47, a workaround is check the situation that "enable tokio in linux" and disable it

This PR adds a new feature -- "force-tokio" and we need to let the user "use feature"  instead of "add feature in photonio dependency", the alternative is to let photonio expose some API to us known whether current runtime support direct_io(e.g. move direct_io_ify() to photonio)