### PR TITLE
page_store: fix page_table in page_file

### DIFF
--- a/src/page_store/page_file/file_builder.rs
+++ b/src/page_store/page_file/file_builder.rs
@@ -66,7 +66,7 @@ impl<'a, E: Env> FileBuilder<'a, E> {
     ) -> Result<()> {
         let file_offset = self.writer.write(page_content).await?;
         self.index.add_data_block(page_addr, file_offset);
-        self.meta.add_page(page_id, page_addr);
+        self.meta.add_page(page_addr, page_id);
         Ok(())
     }
 
@@ -245,8 +245,8 @@ struct MetaBlockBuilder {
 }
 
 impl MetaBlockBuilder {
-    pub(crate) fn add_page(&mut self, page_id: u64, page_addr: u64) {
-        self.page_table.0.insert(page_id, page_addr);
+    pub(crate) fn add_page(&mut self, page_addr: u64, page_id: u64) {
+        self.page_table.0.insert(page_addr, page_id);
     }
 
     pub(crate) fn delete_pages(&mut self, page_addrs: &[u64]) {
@@ -270,7 +270,7 @@ impl MetaBlockBuilder {
 }
 
 #[derive(Default)]
-pub(crate) struct PageTable(BTreeMap<u64, u64>);
+pub(crate) struct PageTable(BTreeMap<u64 /* page addr */, u64 /* page id */>);
 
 impl PageTable {
     fn encode(&self) -> Vec<u8> {

--- a/src/page_store/recover.rs
+++ b/src/page_store/recover.rs
@@ -78,7 +78,7 @@ impl<E: Env> PageStore<E> {
         let table = PageTable::default();
         for file_id in files {
             let meta_reader = page_files.open_meta_reader(file_id).await?;
-            for (page_id, page_addr) in meta_reader.read_page_table().await? {
+            for (page_addr, page_id) in meta_reader.read_page_table().await? {
                 table.set(page_id, page_addr);
             }
         }


### PR DESCRIPTION
closes #224

The old code is buggy, encode/decode/recovery/GC has different assume for "page_addr, page_id" and "page_id, page_addr" - -

This pr let all of them be "page_addr, page_id"