### PR TITLE
page_store: avoid take write guard twice

### DIFF
--- a/src/page_store/page_txn.rs
+++ b/src/page_store/page_txn.rs
@@ -498,7 +498,7 @@ mod tests {
 
     fn assert_current_buffer_is_flushable(version: Arc<Version>) {
         let current = version.buffer_set.current();
-        let buf = current.last_writer_buffer().clone();
+        let buf = current.last_writer_buffer();
         buf.seal().unwrap();
         assert!(buf.is_flushable());
     }


### PR DESCRIPTION
Because the header of the dealloc pages is not saved, it is problematic to judge whether the writer guard is held only based on whether the records are empty. This PR uses a separate field to record whether the writer guard is held.

Closes #235.