### PR TITLE
page_store, tools: refine store_stats

### DIFF
--- a/photondb/src/page_store/page_txn.rs
+++ b/photondb/src/page_store/page_txn.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use super::{
+    stats::AtomicWritebufStats,
     version::Version,
     write_buffer::{RecordHeader, ReleaseState},
     CacheEntry, ClockCache, Error, PageFiles, PageTable, Result, WriteBuffer, NAN_ID,
@@ -24,6 +25,7 @@ where
     page_table: PageTable,
     page_files: Arc<PageFiles<E>>,
     cache_guards: Mutex<Vec<CacheEntryGuard>>,
+    writebuf_stats: Arc<AtomicWritebufStats>,
 }
 
 impl<E: Env> Guard<E> {
@@ -31,12 +33,14 @@ impl<E: Env> Guard<E> {
         version: Arc<Version>,
         page_table: PageTable,
         page_files: Arc<PageFiles<E>>,
+        writebuf_stats: Arc<AtomicWritebufStats>,
     ) -> Self {
         Guard {
             version,
             page_table,
             page_files,
             cache_guards: Mutex::default(),
+            writebuf_stats,
         }
     }
 
@@ -69,8 +73,10 @@ impl<E: Env> Guard<E> {
         let logic_id = (addr >> 32) as u32;
         if let Some(buf) = self.version.get(logic_id) {
             // Safety: all mutable references are released.
+            self.writebuf_stats.read_in_buf.inc();
             return Ok(unsafe { buf.page(addr) });
         }
+        self.writebuf_stats.read_in_file.inc();
 
         let Some(file_info) = self.version.page_files().get(&logic_id) else {
             panic!("File {logic_id} is not exists");
@@ -379,7 +385,7 @@ mod tests {
         let files = Arc::new(PageFiles::new(env, base.path(), &test_option()).await);
         let version = new_version(512);
         let page_table = PageTable::default();
-        let guard = Guard::new(version.clone(), page_table, files);
+        let guard = Guard::new(version.clone(), page_table, files, Default::default());
         let mut page_txn = guard.begin().await;
         let (addr, _) = page_txn.alloc_page(123).await.unwrap();
         let id = page_txn.insert_page(addr);
@@ -397,7 +403,7 @@ mod tests {
 
         let version = new_version(1 << 10);
         let page_table = PageTable::default();
-        let guard = Guard::new(version.clone(), page_table, files);
+        let guard = Guard::new(version.clone(), page_table, files, Default::default());
 
         // insert old page.
         let mut page_txn = guard.begin().await;
@@ -422,7 +428,7 @@ mod tests {
 
         let version = new_version(512);
         let page_table = PageTable::default();
-        let guard = Guard::new(version, page_table, files);
+        let guard = Guard::new(version, page_table, files, Default::default());
         let page_txn = guard.begin().await;
         assert!(matches!(page_txn.update_page(1, 3, 2), Err(None)));
     }
@@ -435,7 +441,7 @@ mod tests {
 
         let version = new_version(1 << 10);
         let page_table = PageTable::default();
-        let guard = Guard::new(version.clone(), page_table, files);
+        let guard = Guard::new(version.clone(), page_table, files, Default::default());
         let mut page_txn = guard.begin().await;
         let (addr, _) = page_txn.alloc_page(123).await.unwrap();
         let id = page_txn.insert_page(addr);
@@ -466,7 +472,7 @@ mod tests {
 
         let version = new_version(512);
         let page_table = PageTable::default();
-        let guard = Guard::new(version, page_table, files);
+        let guard = Guard::new(version, page_table, files, Default::default());
         let mut page_txn = guard.begin().await;
         page_txn.seal_write_buffer().await;
     }
@@ -479,7 +485,7 @@ mod tests {
 
         let version = new_version(512);
         let page_table = PageTable::default();
-        let guard = Guard::new(version, page_table, files);
+        let guard = Guard::new(version, page_table, files, Default::default());
         let mut page_txn_1 = guard.begin().await;
         let mut page_txn_2 = guard.begin().await;
         page_txn_1.seal_write_buffer().await;
@@ -495,7 +501,12 @@ mod tests {
 
         let version = new_version(512);
         let page_table = PageTable::default();
-        let guard = Guard::new(version.clone(), page_table.clone(), files);
+        let guard = Guard::new(
+            version.clone(),
+            page_table.clone(),
+            files,
+            Default::default(),
+        );
         let mut page_txn = guard.begin().await;
         let (addr, _) = page_txn.alloc_page(123).await.unwrap();
         let id = page_txn.insert_page(addr);

--- a/photondb/src/page_store/stats.rs
+++ b/photondb/src/page_store/stats.rs
@@ -1,47 +1,122 @@
+use std::fmt::Display;
+
 use crate::util::atomic::Counter;
 
 /// Statistics of page store.
-#[derive(Clone)]
+#[derive(Clone, Copy, Default)]
 pub struct StoreStats {
     /// Statistics of page cache.
     pub page_cache: CacheStats,
+    /// Statistics of file reader cache.
+    pub file_reader_cache: CacheStats,
+    /// Statistics of writebuf.
+    pub writebuf: WritebufStats,
 }
 
-/// Statistics of pagee cache.
-#[derive(Default, Clone, Debug)]
+impl StoreStats {
+    /// Sub other stats to produce an new stats.
+    pub fn sub(&self, o: &StoreStats) -> StoreStats {
+        StoreStats {
+            page_cache: self.page_cache.sub(&o.page_cache),
+            file_reader_cache: self.file_reader_cache.sub(&o.file_reader_cache),
+            writebuf: self.writebuf.sub(&o.writebuf),
+        }
+    }
+}
+
+impl Display for StoreStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "WritebufStats: read_in_buf: {}, read_in_files: {}, read_hit_rate: {}%",
+            self.writebuf.read_in_buf,
+            self.writebuf.read_in_file,
+            (self.writebuf.read_in_buf as f64) * 100.
+                / (self.writebuf.read_in_buf + self.writebuf.read_in_file) as f64,
+        )?;
+        writeln!(
+            f,
+            "FileReaderCacheStats: lookup_hit: {}, lookup_miss: {}, hit_rate: {}%, insert: {}, active_evit: {}, passive_evit: {}",
+            self.file_reader_cache.lookup_hit,
+            self.file_reader_cache.lookup_miss,
+            (self.file_reader_cache.lookup_hit as f64) * 100.
+                / (self.file_reader_cache.lookup_hit + self.file_reader_cache.lookup_miss) as f64,
+            self.file_reader_cache.insert,
+            self.file_reader_cache.active_evit,
+            self.file_reader_cache.passive_evit,
+        )?;
+        writeln!(
+            f,
+            "PageCacheStats: lookup_hit: {}, lookup_miss: {}, hit_rate: {}%, insert: {}, active_evit: {}, passive_evit: {}",
+            self.page_cache.lookup_hit,
+            self.page_cache.lookup_miss,
+            (self.page_cache.lookup_hit as f64) * 100.
+                / (self.page_cache.lookup_hit + self.page_cache.lookup_miss) as f64,
+            self.page_cache.insert,
+            self.page_cache.active_evit,
+            self.page_cache.passive_evit,
+        )
+    }
+}
+
+/// Statistics of cache.
+#[derive(Default, Clone, Debug, Copy)]
 pub struct CacheStats {
     pub lookup_hit: u64,
     pub lookup_miss: u64,
     pub insert: u64,
     pub active_evit: u64,
+    pub passive_evit: u64,
 }
 
 impl CacheStats {
-    pub fn sub(&self, o: &CacheStats) -> CacheStats {
+    fn sub(&self, o: &CacheStats) -> CacheStats {
         CacheStats {
             lookup_hit: self.lookup_hit.wrapping_sub(o.lookup_hit),
-            lookup_miss: self.lookup_miss.wrapping_sub(o.lookup_hit),
+            lookup_miss: self.lookup_miss.wrapping_sub(o.lookup_miss),
             insert: self.insert.wrapping_sub(o.insert),
             active_evit: self.active_evit.wrapping_sub(o.active_evit),
+            passive_evit: self.passive_evit.wrapping_sub(o.passive_evit),
+        }
+    }
+
+    pub(crate) fn add(&self, o: &CacheStats) -> CacheStats {
+        CacheStats {
+            lookup_hit: self.lookup_hit.wrapping_add(o.lookup_hit),
+            lookup_miss: self.lookup_miss.wrapping_add(o.lookup_miss),
+            insert: self.insert.wrapping_add(o.insert),
+            active_evit: self.active_evit.wrapping_add(o.active_evit),
+            passive_evit: self.passive_evit.wrapping_add(o.passive_evit),
+        }
+    }
+}
+
+#[derive(Default, Clone, Debug, Copy)]
+pub struct WritebufStats {
+    pub read_in_buf: u64,
+    pub read_in_file: u64,
+}
+
+impl WritebufStats {
+    fn sub(&self, o: &WritebufStats) -> WritebufStats {
+        WritebufStats {
+            read_in_buf: self.read_in_buf.wrapping_sub(o.read_in_buf),
+            read_in_file: self.read_in_file.wrapping_sub(o.read_in_file),
         }
     }
 }
 
 #[derive(Default)]
-pub(super) struct AtomicCacheStats {
-    pub(super) lookup_hit: Counter,
-    pub(super) lookup_miss: Counter,
-    pub(super) insert: Counter,
-    pub(super) active_evit: Counter,
+pub(crate) struct AtomicWritebufStats {
+    pub(super) read_in_buf: Counter,
+    pub(super) read_in_file: Counter,
 }
 
-impl AtomicCacheStats {
-    pub(super) fn snapshot(&self) -> CacheStats {
-        CacheStats {
-            lookup_hit: self.lookup_hit.get(),
-            lookup_miss: self.lookup_miss.get(),
-            insert: self.insert.get(),
-            active_evit: self.active_evit.get(),
+impl AtomicWritebufStats {
+    pub(super) fn snapshot(&self) -> WritebufStats {
+        WritebufStats {
+            read_in_buf: self.read_in_buf.get(),
+            read_in_file: self.read_in_file.get(),
         }
     }
 }


### PR DESCRIPTION
Refine store_stats again, add addition stats

- writebuf read stats: how often read from writebuf
- file_reader_stats: how often open new fd
- add passive evit stats in cache

```
Running benchmark for 1 times
FillRandom :       3.000 ms/op 261773.62547217583 ops/sec, 3.82009455 sec, 1000000 ops; 30.889287805716748 MiB/s
TableStats_success: read: 1000044, write: 1000000, split_page: 75, reconcile_page: 75, consolidate_page: 406721
TableStats_conflict: read: 0, write: 44, split_page: 0, reconcile_page: 0, consolidate_page: 2
WritebufStats: read_in_buf: 3226126, read_in_files: 569977, read_hit_rate: 84.98520719801333%
FileReaderCacheStats: lookup_hit: 429623, lookup_miss: 9, hit_rate: 99.9979051839714%, insert: 9, active_evit: 5, passive_evit: 0
PageCacheStats: lookup_hit: 140345, lookup_miss: 429632, hit_rate: 24.622923381118888%, insert: 429632, active_evit: 357560, passive_evit: 424835
Running benchmark for 1 times
ReadRandom :       2.000 ms/op 458033.9707655 ops/sec, 2.183244178 sec, 1000000 ops; 54.048008550329 MiB/s  (reads:1000000 founds:1000000)
TableStats_success: read: 1000000, write: 0, split_page: 0, reconcile_page: 0, consolidate_page: 0
TableStats_conflict: read: 0, write: 0, split_page: 0, reconcile_page: 0, consolidate_page: 0
WritebufStats: read_in_buf: 4118660, read_in_files: 428757, read_hit_rate: 90.57141669655543%
FileReaderCacheStats: lookup_hit: 375363, lookup_miss: 0, hit_rate: 100%, insert: 0, active_evit: 0, passive_evit: 0
PageCacheStats: lookup_hit: 53394, lookup_miss: 375363, hit_rate: 12.45320776103947%, insert: 375363, active_evit: 0, passive_evit: 375365
```
